### PR TITLE
Adapt w.r.t. coq/coq#16004.

### DIFF
--- a/coq/PerformanceDemos/Makefile
+++ b/coq/PerformanceDemos/Makefile
@@ -16,7 +16,7 @@ all:: invoke-coqmakefile
 
 include ../../Makefile.show
 
-WARNINGS:=-notation-overridden
+WARNINGS:=-notation-overridden,-unsupported-attributes
 
 SORT_COQPROJECT = sed 's,[^/]*/,~&,g' | env LC_COLLATE=C sort | sed 's,~,,g' | uniq
 .PHONY: update-_CoqProject

--- a/coq/PerformanceDemos/_CoqProject
+++ b/coq/PerformanceDemos/_CoqProject
@@ -1,5 +1,5 @@
 -R . PerformanceDemos
--arg -w -arg -notation-overridden
+-arg -w -arg -notation-overridden,-unsupported-attributes
 app_n.v
 constr_eq.v
 do_n_binder.v

--- a/coq/PerformanceDemos/rewrite_strat_repeated_app.v
+++ b/coq/PerformanceDemos/rewrite_strat_repeated_app.v
@@ -6,6 +6,7 @@ Axiom fg : forall x, f x = g x.
 Lemma fg_ext : forall x y, x = y -> f x = g y.
 Proof. intros; subst; apply fg. Qed.
 
+#[global]
 Hint Rewrite fg : rew_fg.
 
 Fixpoint comp_pow {A} (f : A -> A) (n : nat) (x : A) {struct n} : A

--- a/coq/PerformanceDemos/rewrite_strat_under_binders.v
+++ b/coq/PerformanceDemos/rewrite_strat_under_binders.v
@@ -3,7 +3,7 @@ Require Import Coq.Classes.Morphisms.
 Require Import Coq.Setoids.Setoid.
 Definition Let_In {A P} (x : A) (f : forall a : A, P a) : P x := let y := x in f y.
 Strategy 100 [Let_In].
-Hint Opaque Let_In : rewrite.
+Global Hint Opaque Let_In : rewrite.
 Reserved Notation "'dlet_nd' x .. y := v 'in' f"
          (at level 200, x binder, y binder, f at level 200, format "'dlet_nd'  x .. y  :=  v  'in' '//' f").
 Reserved Notation "'dlet' x .. y := v 'in' f"
@@ -13,7 +13,7 @@ Notation "'dlet' x .. y := v 'in' f" := (Let_In v (fun x => .. (fun y => f) .. )
 Global Instance Let_In_nd_Proper {A P}
   : Proper (eq ==> pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => P)).
 Proof. cbv; intros; subst; auto. Qed.
-Hint Extern 0 (Proper _ (@Let_In _ _)) => simple apply @Let_In_nd_Proper : typeclass_instances.
+Global Hint Extern 0 (Proper _ (@Let_In _ _)) => simple apply @Let_In_nd_Proper : typeclass_instances.
 Global Instance eq_eq_eq {A}
   : Proper (eq ==> eq ==> eq) (@eq A).
 Proof. repeat intro; subst; reflexivity. Qed.

--- a/coq/PerformanceExperiments/Harness.v
+++ b/coq/PerformanceExperiments/Harness.v
@@ -220,27 +220,27 @@ Definition reflect_rel_of_beq_iff {T} {beq : T -> T -> bool} {R : T -> T -> Prop
   : reflect_rel R beq
   := reflect_rel_of_beq (fun x y => proj1 (bp x y)) (fun x y => proj2 (bp x y)).
 
-Instance reflect_eq_nat : reflect_rel (@eq nat) Nat.eqb
+Global Instance reflect_eq_nat : reflect_rel (@eq nat) Nat.eqb
   := reflect_rel_of_beq_iff Nat.eqb_eq.
 
-Instance reflect_eq_Z : reflect_rel (@eq Z) Z.eqb
+Global Instance reflect_eq_Z : reflect_rel (@eq Z) Z.eqb
   := reflect_rel_of_beq_iff Z.eqb_eq.
 
 Class has_sub T := sub : T -> T -> T.
-Instance: has_sub nat := Nat.sub.
-Instance: has_sub Z := Z.sub.
+Global Instance: has_sub nat := Nat.sub.
+Global Instance: has_sub Z := Z.sub.
 
 Class has_succ T := succ : T -> T.
-Instance: has_succ nat := S.
-Instance: has_succ Z := Z.succ.
+Global Instance: has_succ nat := S.
+Global Instance: has_succ Z := Z.succ.
 
 Class has_zero T := zero : T.
-Instance: has_zero nat := O.
-Instance: has_zero Z := Z0.
+Global Instance: has_zero nat := O.
+Global Instance: has_zero Z := Z0.
 
 Class has_sort T := sort : list T -> list T.
-Instance: has_sort nat := NatSort.sort.
-Instance: has_sort Z := ZSort.sort.
+Global Instance: has_sort nat := NatSort.sort.
+Global Instance: has_sort Z := ZSort.sort.
 
 Definition remove_smaller_args_of_size_by_reflect
            {T} {T_beq : T -> T -> bool}

--- a/coq/PerformanceExperiments/Makefile
+++ b/coq/PerformanceExperiments/Makefile
@@ -25,7 +25,7 @@ all:: invoke-coqmakefile
 copy-perf:: invoke-coqmakefile
 .PHONY: copy-perf
 
-WARNINGS:=-notation-overridden
+WARNINGS:=-notation-overridden,-unsupported-attributes
 
 ifneq ($(wildcard ../../.git),)
 FILE_FINDER := git ls-files

--- a/coq/PerformanceExperiments/rewrite_repeated_app_common.v
+++ b/coq/PerformanceExperiments/rewrite_repeated_app_common.v
@@ -11,6 +11,7 @@ Axiom f' : nat -> nat -> nat.
 Axiom g' : nat -> nat -> nat.
 Axiom f'g' : forall x y, f' x y = g' x y.
 
+#[global]
 Hint Rewrite fg : rew_fg.
 
 Fixpoint comp_pow {A} (f : A -> A) (n : nat) (x : A) {struct n} : A

--- a/coq/PerformanceExperiments/rewrite_under_binders_common.v
+++ b/coq/PerformanceExperiments/rewrite_under_binders_common.v
@@ -17,7 +17,7 @@ Module Type LetInT.
   Notation "'dlet' x .. y := v 'in' f" := (Let_In v (fun x => .. (fun y => f) .. )).
   Axiom Let_In_nd_Proper : forall {A P},
       Proper (eq ==> pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => P)).
-  Hint Extern 0 (Proper _ (@Let_In _ _)) => simple apply @Let_In_nd_Proper : typeclass_instances.
+  Global Hint Extern 0 (Proper _ (@Let_In _ _)) => simple apply @Let_In_nd_Proper : typeclass_instances.
 End LetInT.
 
 Module Export LetIn : LetInT.
@@ -26,7 +26,7 @@ Module Export LetIn : LetInT.
   Lemma Let_In_def : @Let_In = fun A P x f => let y := x in f y.
   Proof. reflexivity. Qed.
   Global Strategy 100 [Let_In].
-  Hint Opaque Let_In : rewrite.
+  Global Hint Opaque Let_In : rewrite.
   Global Instance Let_In_nd_Proper {A P}
     : Proper (eq ==> pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => P)).
   Proof. cbv; intros; subst; auto. Qed.


### PR DESCRIPTION
I've done this one by hand because it's really small. @JasonGross I am unsure of the amount of backwards compatibility you want to preserve, but the only two problematic attributes are the ones for the `Hint Rewrite` commands. Not sure if you want to add a script to simply remove them on old versions, or do something more clever.